### PR TITLE
🔧 `mise`の設定を引き継いだ

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,0 +1,13 @@
+[tools]
+air = "latest"
+buf = "latest"
+lazydocker = "latest"
+lefthook = "latest"
+node = "23.9.0"
+"npm:gitmoji-cli" = "latest"
+pnpm = "latest"
+task = "latest"
+usage = "latest"
+
+[settings]
+experimental = true


### PR DESCRIPTION
既存の`mise`の設定を引き継いだ