### PR TITLE
🔧 機能していないショートカットを削除

### DIFF
--- a/config/nvim/lua/plugin/cmp.lua
+++ b/config/nvim/lua/plugin/cmp.lua
@@ -71,7 +71,6 @@ return {
 							fallback()
 						end
 					end, { "i", "s" }),
-					["<C-l>"] = cmp.mapping.complete(),
 				}),
 				sources = cmp.config.sources({
 					{ name = "nvim_lsp", keyword_length = 1 }, -- LSP


### PR DESCRIPTION
<C-l>で補完画面が開くはずだがうまく動作しなかったため無効化した